### PR TITLE
Fix DoS risk in file upload

### DIFF
--- a/src/main/java/org/sasanlabs/service/vulnerability/fileupload/UnrestrictedFileUpload.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/fileupload/UnrestrictedFileUpload.java
@@ -60,6 +60,7 @@ public class UnrestrictedFileUpload {
             Pattern.compile(CONTAINS_PNG_JPEG_REGEX);
     private static final Pattern ENDS_WITH_PNG_OR_JPEG_PATTERN =
             Pattern.compile(CONTAINS_PNG_JPEG_REGEX + "$");
+    private static final long MAX_FILE_SIZE_BYTES = 5 * 1024 * 1024; // 5MB limit
     private static final transient Logger LOGGER =
             LogManager.getLogger(UnrestrictedFileUpload.class);
 
@@ -111,6 +112,11 @@ public class UnrestrictedFileUpload {
                     boolean isContentDisposition)
                     throws IOException {
         if (validator.get()) {
+            if (file.getSize() > MAX_FILE_SIZE_BYTES) {
+                return new ResponseEntity<>(
+                        new GenericVulnerabilityResponseBean<>("File too large", false),
+                        HttpStatus.PAYLOAD_TOO_LARGE);
+            }
             Path destination = root.resolve(fileName).normalize();
             if (!destination.startsWith(root)) {
                 return new ResponseEntity<>(


### PR DESCRIPTION
## Summary
- limit uploaded file size in `UnrestrictedFileUpload`

## Testing
- `./gradlew test` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_6854b2a31c88832ca89e7746edad1a77