### PR TITLE
Add SpotBugs analysis and secure RNG

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ buildscript {
 //Community Plugins
 plugins {
     id("com.diffplug.spotless") version "5.6.1"
+    id("com.github.spotbugs") version "5.0.14"
     id("com.google.cloud.tools.jib") version "3.3.1"
     id("org.sonarqube") version "3.3"
     id("jacoco")
@@ -157,7 +158,8 @@ dependencies {
     
     implementation group: 'io.github.sasanlabs', name: 'facade-schema', version: '1.0.1'
 
-    implementation group: 'commons-fileupload', name: 'commons-fileupload', version: '1.5.1'
+    implementation group: 'commons-fileupload', name: 'commons-fileupload', version: '1.5'
+    spotbugsPlugins 'com.h3xstream.findsecbugs:findsecbugs-plugin:1.13.0'
 }
 
 test {
@@ -165,12 +167,27 @@ test {
     finalizedBy jacocoTestReport
 }
 
-jacocoTestReport {
-    dependsOn test
+    jacocoTestReport {
+        dependsOn test
+        reports {
+                xml.enabled true
+                html.enabled true
+                csv.enabled false
+                xml.destination file("${buildDir}/reports/jacoco.xml")
+        }
+    }
+
+spotbugs {
+    toolVersion = "4.8.3"
+    effort = "max"
+    reportLevel = "low"
+}
+
+tasks.withType(com.github.spotbugs.snom.SpotBugsTask).configureEach {
+    ignoreFailures = true
     reports {
-            xml.enabled true
-            html.enabled true
-            csv.enabled false
-            xml.destination file("${buildDir}/reports/jacoco.xml")
+        xml.required.set(false)
+        html.required.set(true)
+        html.outputLocation.set(file("${buildDir}/reports/spotbugs/${name}.html"))
     }
 }

--- a/src/main/java/org/sasanlabs/service/vulnerability/fileupload/UnrestrictedFileUpload.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/fileupload/UnrestrictedFileUpload.java
@@ -9,8 +9,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
-import java.util.Date;
-import java.util.Random;
+import java.security.SecureRandom;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import org.apache.commons.text.StringEscapeUtils;
@@ -50,7 +49,7 @@ public class UnrestrictedFileUpload {
     static final String CONTENT_DISPOSITION_STATIC_FILE_LOCATION = "contentDispositionUpload";
     private static final String BASE_PATH = "static";
     private static final String REQUEST_PARAMETER = "file";
-    private static final Random RANDOM = new Random(new Date().getTime());
+    private static final SecureRandom RANDOM = new SecureRandom();
     private static final Pattern ENDS_WITH_HTML_PATTERN = Pattern.compile("^.+\\.html$");
     private static final Pattern ENDS_WITH_HTML_OR_HTM_PATTERN =
             Pattern.compile("^.+\\.(html|htm)$");


### PR DESCRIPTION
## Summary
- integrate SpotBugs with FindSecurityBugs plugin
- allow SpotBugs to run without failing the build
- fix predictable random generator in `UnrestrictedFileUpload`
- correct file upload dependency version

## Testing
- `./gradlew spotbugsMain`
- `./gradlew spotbugsTest`
- `./gradlew test` *(fails: Error while instrumenting CLDRLocaleDataMetaInfo)*

------
https://chatgpt.com/codex/tasks/task_e_6854b76354c8832ca052381d4d2b5146