### PR TITLE
Fix insecure regex patterns in XSS filters

### DIFF
--- a/src/main/java/org/sasanlabs/service/vulnerability/xss/persistent/PersistentXSSInHTMLTagVulnerability.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/xss/persistent/PersistentXSSInHTMLTagVulnerability.java
@@ -22,9 +22,14 @@ import org.springframework.web.bind.annotation.RequestParam;
 public class PersistentXSSInHTMLTagVulnerability {
 
     private static final String PARAMETER_NAME = "comment";
-    private static final Pattern IMG_INPUT_TAG_PATTERN = Pattern.compile("(<img)|(<input)+");
+    // Detect <img> or <input> tags. The previous regular expressions used character
+    // classes and repetition in a way that allowed bypasses and false positives.
+    // Use explicit alternatives and, for the case insensitive pattern, enable the
+    // CASE_INSENSITIVE flag for robustness.
+    private static final Pattern IMG_INPUT_TAG_PATTERN =
+            Pattern.compile("<\\s*(?:img|input)[^>]*>");
     private static final Pattern IMG_INPUT_TAG_CASE_INSENSITIVE_PATTERN =
-            Pattern.compile("((?i)<img)|((?i)<script)+");
+            Pattern.compile("<\\s*(?:img|input)[^>]*>", Pattern.CASE_INSENSITIVE);
 
     private PostRepository postRepository;
 

--- a/src/main/java/org/sasanlabs/service/vulnerability/xss/reflected/XSSWithHtmlTagInjection.java
+++ b/src/main/java/org/sasanlabs/service/vulnerability/xss/reflected/XSSWithHtmlTagInjection.java
@@ -51,7 +51,9 @@ public class XSSWithHtmlTagInjection {
             @RequestParam Map<String, String> queryParams) {
         String vulnerablePayloadWithPlaceHolder = "<div>%s<div>";
         StringBuilder payload = new StringBuilder();
-        Pattern pattern = Pattern.compile("[<]+[(script)(img)(a)]+.*[>]+");
+        // Previous regular expression incorrectly used character classes which
+        // allowed easy bypasses. Match explicit HTML tags instead.
+        Pattern pattern = Pattern.compile("<\\s*(?:script|img|a)[^>]*>");
         for (Map.Entry<String, String> map : queryParams.entrySet()) {
             Matcher matcher = pattern.matcher(map.getValue());
             if (!matcher.find()) {
@@ -74,7 +76,7 @@ public class XSSWithHtmlTagInjection {
             @RequestParam Map<String, String> queryParams) {
         String vulnerablePayloadWithPlaceHolder = "<div>%s<div>";
         StringBuilder payload = new StringBuilder();
-        Pattern pattern = Pattern.compile("[<]+[(script)(img)(a)]+.*[>]+");
+        Pattern pattern = Pattern.compile("<\\s*(?:script|img|a)[^>]*>");
         for (Map.Entry<String, String> map : queryParams.entrySet()) {
             Matcher matcher = pattern.matcher(map.getValue());
             if (!matcher.find()


### PR DESCRIPTION
## Summary
- tighten regex patterns used to filter HTML tags in the persistent and reflected XSS services

## Testing
- `./gradlew test -q` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_6854bab6f670832c88c995d52ee15613